### PR TITLE
Fix: Ensure sub-device data from gateways is handled as a dictionary

### DIFF
--- a/tuya_web_server/main.py
+++ b/tuya_web_server/main.py
@@ -502,8 +502,17 @@ async def get_device_status(device_id: str):
             gateway_device = tinytuya.Device(dev_id=device_info['device_id'], address=device_info['ip'], local_key=device_info['local_key'], version=float(device_info.get('version', 3.3)))
             gateway_device.set_socketRetryLimit(1)
             sub_devices_result = gateway_device.subdev_query()
-            # Assuming subdev_query returns a dictionary or similar structure
-            sub_devices = sub_devices_result if sub_devices_result else {}
+
+            # Ensure sub_devices is a dictionary
+            if isinstance(sub_devices_result, str):
+                try:
+                    sub_devices = json.loads(sub_devices_result)
+                except json.JSONDecodeError:
+                    sub_devices = {"error": "Invalid JSON from subdev_query"}
+            elif sub_devices_result:
+                sub_devices = sub_devices_result
+            else:
+                sub_devices = {}
         except Exception as e:
             logger.warning(f"Could not get sub-devices for gateway {device_id}: {e}")
             sub_devices = {"error": f"Failed to get sub-devices: {e}"}


### PR DESCRIPTION
This commit fixes a bug where the sub-device data returned by `subdev_query()` was sometimes treated as a string, causing the frontend to fail to display the sub-device list correctly.

- The `get_device_status` function in `main.py` now checks if the result from `subdev_query()` is a string.
- If it is a string, it attempts to parse it as JSON.
- This ensures that the `sub_devices` field in the API response is always a dictionary, which the frontend can correctly parse and render.